### PR TITLE
fix problem with empty runtime dependencies

### DIFF
--- a/port_deptree.py
+++ b/port_deptree.py
@@ -55,7 +55,10 @@ def get_deps(portname, variants):
         if not section.endswith("Dependencies"):
             continue
         for child in [child.strip() for child in children.split(",")]:
-            yield section.split()[0].lower(), child
+            section = section.split()[0].lower()
+            child = child.strip()
+            if child:
+                yield section, child
 
 
 def make_graph(graph, portname, variants):

--- a/port_deptree.py
+++ b/port_deptree.py
@@ -90,7 +90,7 @@ def make_graph(graph, portname, variants):
         elif parent in installed:
             node_data.status = "installed"
         for section, child in get_deps(parent.strip('"'), variants):
-            if node_data.type is not "root":
+            if node_data.type != "root":
                 node_data.type = "vertex"
             if child not in graph:
                 graph.add_node(child, NodeData("leaf"))
@@ -107,7 +107,7 @@ def reduce_graph(graph, root):
     """Keep only "missing" and "outdated" nodes and their parents."""
     for node in graph.forw_bfs(root):
         node_data = graph.node_data(node)
-        if node_data.type is "root" or node_data.status is not "installed":
+        if node_data.type == "root" or node_data.status != "installed":
             continue
         children = set(graph.tail(edge) for edge in graph.out_edges(node))
         if not set(("outdated", "missing")).intersection(
@@ -137,7 +137,7 @@ def make_dot(graph):
     dot.style(overlap=False, bgcolor="transparent")
     for node in graph:
         node_data = graph.node_data(node)
-        shape = "circle" if node_data.type is "vertex" else "doublecircle"
+        shape = "circle" if node_data.type == "vertex" else "doublecircle"
         color, fillcolor = dict(
             missing=("red", "moccasin"), outdated=("forestgreen", "lightblue")
         ).get(node_data.status, ("black", "white"))


### PR DESCRIPTION
This PR fixes some linting problems due to identity checks with string literals,
and then addresses a problem with empty runtime dependencies:
```
Error: A default port name could not be supplied.
Error: Unable to open port: Could not find Portfile in /Users/hmeine/System/macports_deptree
```
which is caused by `port deps libgcc-devel` outputting
```
Full Name: libgcc-devel @12-20220327_0+enable_stdlib_flag
Build Dependencies:   texinfo, cctools, gmp, isl, ld64, libiconv, libmpc, mpfr, zstd
Library Dependencies: zlib
Runtime Dependencies:
```
and port_deptree.py interpreting the last line as a single dependency with an empty name.
(`port deps` without further arguments then leads to the above message, because `port`
thinks it should look in the current directory for a `Portfile`.)
